### PR TITLE
Add OiCS Examples for 2.0.0 @ 1.20.0 compatibility

### DIFF
--- a/autoscaler_basic/main.tf
+++ b/autoscaler_basic/main.tf
@@ -3,7 +3,7 @@ resource "google_compute_autoscaler" "foobar" {
   zone   = "us-central1-f"
   target = "${google_compute_instance_group_manager.foobar.self_link}"
 
-  autoscaling_policy = {
+  autoscaling_policy {
     max_replicas    = 5
     min_replicas    = 1
     cooldown_period = 60
@@ -29,7 +29,7 @@ resource "google_compute_instance_template" "foobar" {
     network = "default"
   }
 
-  metadata {
+  metadata = {
     foo = "bar"
   }
 
@@ -46,7 +46,10 @@ resource "google_compute_instance_group_manager" "foobar" {
   name = "my-igm-${local.name_suffix}"
   zone = "us-central1-f"
 
-  instance_template  = "${google_compute_instance_template.foobar.self_link}"
+  version {
+    instance_template  = "${google_compute_instance_template.foobar.self_link}"
+    name               = "primary"
+  }
   target_pools       = ["${google_compute_target_pool.foobar.self_link}"]
   base_instance_name = "foobar"
 }

--- a/autoscaler_basic/main.tf
+++ b/autoscaler_basic/main.tf
@@ -46,10 +46,7 @@ resource "google_compute_instance_group_manager" "foobar" {
   name = "my-igm-${local.name_suffix}"
   zone = "us-central1-f"
 
-  version {
-    instance_template  = "${google_compute_instance_template.foobar.self_link}"
-    name               = "primary"
-  }
+  instance_template  = "${google_compute_instance_template.foobar.self_link}"
   target_pools       = ["${google_compute_target_pool.foobar.self_link}"]
   base_instance_name = "foobar"
 }

--- a/cloudbuild_trigger_filename/backing_file.tf
+++ b/cloudbuild_trigger_filename/backing_file.tf
@@ -1,0 +1,15 @@
+# This file has some scaffolding to make sure that names are unique and that
+# a region and zone are selected when you try to create your Terraform resources.
+
+locals {
+  name_suffix = "${random_pet.suffix.id}"
+}
+
+resource "random_pet" "suffix" {
+  length = 2
+}
+
+provider "google" {
+  region = "us-central1"
+  zone   = "us-central1-c"
+}

--- a/cloudbuild_trigger_filename/main.tf
+++ b/cloudbuild_trigger_filename/main.tf
@@ -1,0 +1,13 @@
+resource "google_cloudbuild_trigger" "filename-trigger" {
+  trigger_template {
+    branch_name = "master"
+    repo_name   = "my-repo"
+  }
+
+  substitutions = {
+    _FOO = "bar"
+    _BAZ = "qux"
+  }
+
+  filename = "cloudbuild.yaml"
+}

--- a/cloudbuild_trigger_filename/motd
+++ b/cloudbuild_trigger_filename/motd
@@ -1,0 +1,7 @@
+===
+
+These examples use real resources that will be billed to the
+Google Cloud Platform project you use - so make sure that you
+run "terraform destroy" before quitting!
+
+===

--- a/cloudbuild_trigger_filename/tutorial.md
+++ b/cloudbuild_trigger_filename/tutorial.md
@@ -1,0 +1,79 @@
+# Cloudbuild Trigger Filename - Terraform
+
+## Setup
+
+<walkthrough-author name="rileykarson@google.com" analyticsId="UA-125550242-1" tutorialName="cloudbuild_trigger_filename" repositoryUrl="https://github.com/terraform-google-modules/docs-examples"></walkthrough-author>
+
+Welcome to Terraform in Google Cloud Shell! We need you to let us know what project you'd like to use with Terraform.
+
+<walkthrough-project-billing-setup></walkthrough-project-billing-setup>
+
+Terraform provisions real GCP resources, so anything you create in this session will be billed against this project.
+
+## Terraforming!
+
+Let's use {{project-id}} with Terraform! Click the Cloud Shell icon below to copy the command
+to your shell, and then run it from the shell by pressing Enter/Return. Terraform will pick up
+the project name from the environment variable.
+
+```bash
+export GOOGLE_CLOUD_PROJECT={{project-id}}
+```
+
+After that, let's get Terraform started. Run the following to pull in the providers.
+
+```bash
+terraform init
+```
+
+With the providers downloaded and a project set, you're ready to use Terraform. Go ahead!
+
+```bash
+terraform apply
+```
+
+Terraform will show you what it plans to do, and prompt you to accept. Type "yes" to accept the plan.
+
+```bash
+yes
+```
+
+
+## Post-Apply
+
+### Editing your config
+
+Now you've provisioned your resources in GCP! If you run a "plan", you should see no changes needed.
+
+```bash
+terraform plan
+```
+
+So let's make a change! Try editing a number, or appending a value to the name in the editor. Then,
+run a 'plan' again.
+
+```bash
+terraform plan
+```
+
+Afterwards you can run an apply, which implicitly does a plan and shows you the intended changes
+at the 'yes' prompt.
+
+```bash
+terraform apply
+```
+
+```bash
+yes
+```
+
+## Cleanup
+
+Run the following to remove the resources Terraform provisioned:
+
+```bash
+terraform destroy
+```
+```bash
+yes
+```

--- a/disk_basic/main.tf
+++ b/disk_basic/main.tf
@@ -3,7 +3,7 @@ resource "google_compute_disk" "default" {
   type  = "pd-ssd"
   zone  = "us-central1-a"
   image = "debian-8-jessie-v20170523"
-  labels {
+  labels = {
     environment = "dev"
   }
 }

--- a/dns_managed_zone_basic/backing_file.tf
+++ b/dns_managed_zone_basic/backing_file.tf
@@ -1,0 +1,15 @@
+# This file has some scaffolding to make sure that names are unique and that
+# a region and zone are selected when you try to create your Terraform resources.
+
+locals {
+  name_suffix = "${random_pet.suffix.id}"
+}
+
+resource "random_pet" "suffix" {
+  length = 2
+}
+
+provider "google" {
+  region = "us-central1"
+  zone   = "us-central1-c"
+}

--- a/dns_managed_zone_basic/main.tf
+++ b/dns_managed_zone_basic/main.tf
@@ -1,0 +1,12 @@
+resource "google_dns_managed_zone" "example-zone" {
+  name = "example-zone"
+  dns_name = "example-${random_id.rnd.hex}.com."
+  description = "Example DNS zone"
+  labels = {
+    foo = "bar"
+  }
+}
+
+resource "random_id" "rnd" {
+  byte_length = 4
+}

--- a/dns_managed_zone_basic/motd
+++ b/dns_managed_zone_basic/motd
@@ -1,0 +1,7 @@
+===
+
+These examples use real resources that will be billed to the
+Google Cloud Platform project you use - so make sure that you
+run "terraform destroy" before quitting!
+
+===

--- a/dns_managed_zone_basic/tutorial.md
+++ b/dns_managed_zone_basic/tutorial.md
@@ -1,0 +1,79 @@
+# Dns Managed Zone Basic - Terraform
+
+## Setup
+
+<walkthrough-author name="rileykarson@google.com" analyticsId="UA-125550242-1" tutorialName="dns_managed_zone_basic" repositoryUrl="https://github.com/terraform-google-modules/docs-examples"></walkthrough-author>
+
+Welcome to Terraform in Google Cloud Shell! We need you to let us know what project you'd like to use with Terraform.
+
+<walkthrough-project-billing-setup></walkthrough-project-billing-setup>
+
+Terraform provisions real GCP resources, so anything you create in this session will be billed against this project.
+
+## Terraforming!
+
+Let's use {{project-id}} with Terraform! Click the Cloud Shell icon below to copy the command
+to your shell, and then run it from the shell by pressing Enter/Return. Terraform will pick up
+the project name from the environment variable.
+
+```bash
+export GOOGLE_CLOUD_PROJECT={{project-id}}
+```
+
+After that, let's get Terraform started. Run the following to pull in the providers.
+
+```bash
+terraform init
+```
+
+With the providers downloaded and a project set, you're ready to use Terraform. Go ahead!
+
+```bash
+terraform apply
+```
+
+Terraform will show you what it plans to do, and prompt you to accept. Type "yes" to accept the plan.
+
+```bash
+yes
+```
+
+
+## Post-Apply
+
+### Editing your config
+
+Now you've provisioned your resources in GCP! If you run a "plan", you should see no changes needed.
+
+```bash
+terraform plan
+```
+
+So let's make a change! Try editing a number, or appending a value to the name in the editor. Then,
+run a 'plan' again.
+
+```bash
+terraform plan
+```
+
+Afterwards you can run an apply, which implicitly does a plan and shows you the intended changes
+at the 'yes' prompt.
+
+```bash
+terraform apply
+```
+
+```bash
+yes
+```
+
+## Cleanup
+
+Run the following to remove the resources Terraform provisioned:
+
+```bash
+terraform destroy
+```
+```bash
+yes
+```

--- a/image_basic/backing_file.tf
+++ b/image_basic/backing_file.tf
@@ -1,0 +1,15 @@
+# This file has some scaffolding to make sure that names are unique and that
+# a region and zone are selected when you try to create your Terraform resources.
+
+locals {
+  name_suffix = "${random_pet.suffix.id}"
+}
+
+resource "random_pet" "suffix" {
+  length = 2
+}
+
+provider "google" {
+  region = "us-central1"
+  zone   = "us-central1-c"
+}

--- a/image_basic/main.tf
+++ b/image_basic/main.tf
@@ -1,0 +1,7 @@
+resource "google_compute_image" "example" {
+  name = "example-image-${local.name_suffix}"
+
+  raw_disk {
+    source = "https://storage.googleapis.com/bosh-cpi-artifacts/bosh-stemcell-3262.4-google-kvm-ubuntu-trusty-go_agent-raw.tar.gz"
+  }
+}

--- a/image_basic/motd
+++ b/image_basic/motd
@@ -1,0 +1,7 @@
+===
+
+These examples use real resources that will be billed to the
+Google Cloud Platform project you use - so make sure that you
+run "terraform destroy" before quitting!
+
+===

--- a/image_basic/tutorial.md
+++ b/image_basic/tutorial.md
@@ -1,0 +1,79 @@
+# Image Basic - Terraform
+
+## Setup
+
+<walkthrough-author name="rileykarson@google.com" analyticsId="UA-125550242-1" tutorialName="image_basic" repositoryUrl="https://github.com/terraform-google-modules/docs-examples"></walkthrough-author>
+
+Welcome to Terraform in Google Cloud Shell! We need you to let us know what project you'd like to use with Terraform.
+
+<walkthrough-project-billing-setup></walkthrough-project-billing-setup>
+
+Terraform provisions real GCP resources, so anything you create in this session will be billed against this project.
+
+## Terraforming!
+
+Let's use {{project-id}} with Terraform! Click the Cloud Shell icon below to copy the command
+to your shell, and then run it from the shell by pressing Enter/Return. Terraform will pick up
+the project name from the environment variable.
+
+```bash
+export GOOGLE_CLOUD_PROJECT={{project-id}}
+```
+
+After that, let's get Terraform started. Run the following to pull in the providers.
+
+```bash
+terraform init
+```
+
+With the providers downloaded and a project set, you're ready to use Terraform. Go ahead!
+
+```bash
+terraform apply
+```
+
+Terraform will show you what it plans to do, and prompt you to accept. Type "yes" to accept the plan.
+
+```bash
+yes
+```
+
+
+## Post-Apply
+
+### Editing your config
+
+Now you've provisioned your resources in GCP! If you run a "plan", you should see no changes needed.
+
+```bash
+terraform plan
+```
+
+So let's make a change! Try editing a number, or appending a value to the name in the editor. Then,
+run a 'plan' again.
+
+```bash
+terraform plan
+```
+
+Afterwards you can run an apply, which implicitly does a plan and shows you the intended changes
+at the 'yes' prompt.
+
+```bash
+terraform apply
+```
+
+```bash
+yes
+```
+
+## Cleanup
+
+Run the following to remove the resources Terraform provisioned:
+
+```bash
+terraform destroy
+```
+```bash
+yes
+```

--- a/monitoring_alert_policy_basic/backing_file.tf
+++ b/monitoring_alert_policy_basic/backing_file.tf
@@ -1,0 +1,15 @@
+# This file has some scaffolding to make sure that names are unique and that
+# a region and zone are selected when you try to create your Terraform resources.
+
+locals {
+  name_suffix = "${random_pet.suffix.id}"
+}
+
+resource "random_pet" "suffix" {
+  length = 2
+}
+
+provider "google" {
+  region = "us-central1"
+  zone   = "us-central1-c"
+}

--- a/monitoring_alert_policy_basic/main.tf
+++ b/monitoring_alert_policy_basic/main.tf
@@ -1,0 +1,16 @@
+resource "google_monitoring_alert_policy" "alert_policy" {
+  display_name = "My Alert Policy-${local.name_suffix}"
+  combiner = "OR"
+  conditions {
+    display_name = "test condition"
+    condition_threshold {
+      filter = "metric.type=\"compute.googleapis.com/instance/disk/write_bytes_count\" AND resource.type=\"gce_instance\""
+      duration = "60s"
+      comparison = "COMPARISON_GT"
+      aggregations {
+        alignment_period = "60s"
+        per_series_aligner = "ALIGN_RATE"
+      }
+    }
+  }
+}

--- a/monitoring_alert_policy_basic/motd
+++ b/monitoring_alert_policy_basic/motd
@@ -1,0 +1,7 @@
+===
+
+These examples use real resources that will be billed to the
+Google Cloud Platform project you use - so make sure that you
+run "terraform destroy" before quitting!
+
+===

--- a/monitoring_alert_policy_basic/tutorial.md
+++ b/monitoring_alert_policy_basic/tutorial.md
@@ -1,0 +1,79 @@
+# Monitoring Alert Policy Basic - Terraform
+
+## Setup
+
+<walkthrough-author name="rileykarson@google.com" analyticsId="UA-125550242-1" tutorialName="monitoring_alert_policy_basic" repositoryUrl="https://github.com/terraform-google-modules/docs-examples"></walkthrough-author>
+
+Welcome to Terraform in Google Cloud Shell! We need you to let us know what project you'd like to use with Terraform.
+
+<walkthrough-project-billing-setup></walkthrough-project-billing-setup>
+
+Terraform provisions real GCP resources, so anything you create in this session will be billed against this project.
+
+## Terraforming!
+
+Let's use {{project-id}} with Terraform! Click the Cloud Shell icon below to copy the command
+to your shell, and then run it from the shell by pressing Enter/Return. Terraform will pick up
+the project name from the environment variable.
+
+```bash
+export GOOGLE_CLOUD_PROJECT={{project-id}}
+```
+
+After that, let's get Terraform started. Run the following to pull in the providers.
+
+```bash
+terraform init
+```
+
+With the providers downloaded and a project set, you're ready to use Terraform. Go ahead!
+
+```bash
+terraform apply
+```
+
+Terraform will show you what it plans to do, and prompt you to accept. Type "yes" to accept the plan.
+
+```bash
+yes
+```
+
+
+## Post-Apply
+
+### Editing your config
+
+Now you've provisioned your resources in GCP! If you run a "plan", you should see no changes needed.
+
+```bash
+terraform plan
+```
+
+So let's make a change! Try editing a number, or appending a value to the name in the editor. Then,
+run a 'plan' again.
+
+```bash
+terraform plan
+```
+
+Afterwards you can run an apply, which implicitly does a plan and shows you the intended changes
+at the 'yes' prompt.
+
+```bash
+terraform apply
+```
+
+```bash
+yes
+```
+
+## Cleanup
+
+Run the following to remove the resources Terraform provisioned:
+
+```bash
+terraform destroy
+```
+```bash
+yes
+```

--- a/monitoring_group_basic/backing_file.tf
+++ b/monitoring_group_basic/backing_file.tf
@@ -1,0 +1,15 @@
+# This file has some scaffolding to make sure that names are unique and that
+# a region and zone are selected when you try to create your Terraform resources.
+
+locals {
+  name_suffix = "${random_pet.suffix.id}"
+}
+
+resource "random_pet" "suffix" {
+  length = 2
+}
+
+provider "google" {
+  region = "us-central1"
+  zone   = "us-central1-c"
+}

--- a/monitoring_group_basic/main.tf
+++ b/monitoring_group_basic/main.tf
@@ -1,0 +1,5 @@
+resource "google_monitoring_group" "basic" {
+  display_name = "New Test Group-${local.name_suffix}"
+
+  filter = "resource.metadata.region=\"europe-west2\""
+}

--- a/monitoring_group_basic/motd
+++ b/monitoring_group_basic/motd
@@ -1,0 +1,7 @@
+===
+
+These examples use real resources that will be billed to the
+Google Cloud Platform project you use - so make sure that you
+run "terraform destroy" before quitting!
+
+===

--- a/monitoring_group_basic/tutorial.md
+++ b/monitoring_group_basic/tutorial.md
@@ -1,0 +1,79 @@
+# Monitoring Group Basic - Terraform
+
+## Setup
+
+<walkthrough-author name="rileykarson@google.com" analyticsId="UA-125550242-1" tutorialName="monitoring_group_basic" repositoryUrl="https://github.com/terraform-google-modules/docs-examples"></walkthrough-author>
+
+Welcome to Terraform in Google Cloud Shell! We need you to let us know what project you'd like to use with Terraform.
+
+<walkthrough-project-billing-setup></walkthrough-project-billing-setup>
+
+Terraform provisions real GCP resources, so anything you create in this session will be billed against this project.
+
+## Terraforming!
+
+Let's use {{project-id}} with Terraform! Click the Cloud Shell icon below to copy the command
+to your shell, and then run it from the shell by pressing Enter/Return. Terraform will pick up
+the project name from the environment variable.
+
+```bash
+export GOOGLE_CLOUD_PROJECT={{project-id}}
+```
+
+After that, let's get Terraform started. Run the following to pull in the providers.
+
+```bash
+terraform init
+```
+
+With the providers downloaded and a project set, you're ready to use Terraform. Go ahead!
+
+```bash
+terraform apply
+```
+
+Terraform will show you what it plans to do, and prompt you to accept. Type "yes" to accept the plan.
+
+```bash
+yes
+```
+
+
+## Post-Apply
+
+### Editing your config
+
+Now you've provisioned your resources in GCP! If you run a "plan", you should see no changes needed.
+
+```bash
+terraform plan
+```
+
+So let's make a change! Try editing a number, or appending a value to the name in the editor. Then,
+run a 'plan' again.
+
+```bash
+terraform plan
+```
+
+Afterwards you can run an apply, which implicitly does a plan and shows you the intended changes
+at the 'yes' prompt.
+
+```bash
+terraform apply
+```
+
+```bash
+yes
+```
+
+## Cleanup
+
+Run the following to remove the resources Terraform provisioned:
+
+```bash
+terraform destroy
+```
+```bash
+yes
+```

--- a/monitoring_group_subgroup/backing_file.tf
+++ b/monitoring_group_subgroup/backing_file.tf
@@ -1,0 +1,15 @@
+# This file has some scaffolding to make sure that names are unique and that
+# a region and zone are selected when you try to create your Terraform resources.
+
+locals {
+  name_suffix = "${random_pet.suffix.id}"
+}
+
+resource "random_pet" "suffix" {
+  length = 2
+}
+
+provider "google" {
+  region = "us-central1"
+  zone   = "us-central1-c"
+}

--- a/monitoring_group_subgroup/main.tf
+++ b/monitoring_group_subgroup/main.tf
@@ -1,0 +1,10 @@
+resource "google_monitoring_group" "parent" {
+  display_name = "New Test SubGroup-${local.name_suffix}"
+  filter = "resource.metadata.region=\"europe-west2\""
+}
+
+resource "google_monitoring_group" "subgroup" {
+  display_name = "New Test SubGroup-${local.name_suffix}"
+  filter = "resource.metadata.region=\"europe-west2\""
+  parent_name =  "${google_monitoring_group.parent.name}"
+}

--- a/monitoring_group_subgroup/motd
+++ b/monitoring_group_subgroup/motd
@@ -1,0 +1,7 @@
+===
+
+These examples use real resources that will be billed to the
+Google Cloud Platform project you use - so make sure that you
+run "terraform destroy" before quitting!
+
+===

--- a/monitoring_group_subgroup/tutorial.md
+++ b/monitoring_group_subgroup/tutorial.md
@@ -1,0 +1,79 @@
+# Monitoring Group Subgroup - Terraform
+
+## Setup
+
+<walkthrough-author name="rileykarson@google.com" analyticsId="UA-125550242-1" tutorialName="monitoring_group_subgroup" repositoryUrl="https://github.com/terraform-google-modules/docs-examples"></walkthrough-author>
+
+Welcome to Terraform in Google Cloud Shell! We need you to let us know what project you'd like to use with Terraform.
+
+<walkthrough-project-billing-setup></walkthrough-project-billing-setup>
+
+Terraform provisions real GCP resources, so anything you create in this session will be billed against this project.
+
+## Terraforming!
+
+Let's use {{project-id}} with Terraform! Click the Cloud Shell icon below to copy the command
+to your shell, and then run it from the shell by pressing Enter/Return. Terraform will pick up
+the project name from the environment variable.
+
+```bash
+export GOOGLE_CLOUD_PROJECT={{project-id}}
+```
+
+After that, let's get Terraform started. Run the following to pull in the providers.
+
+```bash
+terraform init
+```
+
+With the providers downloaded and a project set, you're ready to use Terraform. Go ahead!
+
+```bash
+terraform apply
+```
+
+Terraform will show you what it plans to do, and prompt you to accept. Type "yes" to accept the plan.
+
+```bash
+yes
+```
+
+
+## Post-Apply
+
+### Editing your config
+
+Now you've provisioned your resources in GCP! If you run a "plan", you should see no changes needed.
+
+```bash
+terraform plan
+```
+
+So let's make a change! Try editing a number, or appending a value to the name in the editor. Then,
+run a 'plan' again.
+
+```bash
+terraform plan
+```
+
+Afterwards you can run an apply, which implicitly does a plan and shows you the intended changes
+at the 'yes' prompt.
+
+```bash
+terraform apply
+```
+
+```bash
+yes
+```
+
+## Cleanup
+
+Run the following to remove the resources Terraform provisioned:
+
+```bash
+terraform destroy
+```
+```bash
+yes
+```

--- a/notification_channel_basic/backing_file.tf
+++ b/notification_channel_basic/backing_file.tf
@@ -1,0 +1,15 @@
+# This file has some scaffolding to make sure that names are unique and that
+# a region and zone are selected when you try to create your Terraform resources.
+
+locals {
+  name_suffix = "${random_pet.suffix.id}"
+}
+
+resource "random_pet" "suffix" {
+  length = 2
+}
+
+provider "google" {
+  region = "us-central1"
+  zone   = "us-central1-c"
+}

--- a/notification_channel_basic/main.tf
+++ b/notification_channel_basic/main.tf
@@ -1,0 +1,7 @@
+resource "google_monitoring_notification_channel" "basic" {
+  display_name = "Test Notification Channel-${local.name_suffix}"
+  type = "email"
+  labels = {
+    email_address = "fake_email@blahblah.com"
+  }
+}

--- a/notification_channel_basic/motd
+++ b/notification_channel_basic/motd
@@ -1,0 +1,7 @@
+===
+
+These examples use real resources that will be billed to the
+Google Cloud Platform project you use - so make sure that you
+run "terraform destroy" before quitting!
+
+===

--- a/notification_channel_basic/tutorial.md
+++ b/notification_channel_basic/tutorial.md
@@ -1,0 +1,79 @@
+# Notification Channel Basic - Terraform
+
+## Setup
+
+<walkthrough-author name="rileykarson@google.com" analyticsId="UA-125550242-1" tutorialName="notification_channel_basic" repositoryUrl="https://github.com/terraform-google-modules/docs-examples"></walkthrough-author>
+
+Welcome to Terraform in Google Cloud Shell! We need you to let us know what project you'd like to use with Terraform.
+
+<walkthrough-project-billing-setup></walkthrough-project-billing-setup>
+
+Terraform provisions real GCP resources, so anything you create in this session will be billed against this project.
+
+## Terraforming!
+
+Let's use {{project-id}} with Terraform! Click the Cloud Shell icon below to copy the command
+to your shell, and then run it from the shell by pressing Enter/Return. Terraform will pick up
+the project name from the environment variable.
+
+```bash
+export GOOGLE_CLOUD_PROJECT={{project-id}}
+```
+
+After that, let's get Terraform started. Run the following to pull in the providers.
+
+```bash
+terraform init
+```
+
+With the providers downloaded and a project set, you're ready to use Terraform. Go ahead!
+
+```bash
+terraform apply
+```
+
+Terraform will show you what it plans to do, and prompt you to accept. Type "yes" to accept the plan.
+
+```bash
+yes
+```
+
+
+## Post-Apply
+
+### Editing your config
+
+Now you've provisioned your resources in GCP! If you run a "plan", you should see no changes needed.
+
+```bash
+terraform plan
+```
+
+So let's make a change! Try editing a number, or appending a value to the name in the editor. Then,
+run a 'plan' again.
+
+```bash
+terraform plan
+```
+
+Afterwards you can run an apply, which implicitly does a plan and shows you the intended changes
+at the 'yes' prompt.
+
+```bash
+terraform apply
+```
+
+```bash
+yes
+```
+
+## Cleanup
+
+Run the following to remove the resources Terraform provisioned:
+
+```bash
+terraform destroy
+```
+```bash
+yes
+```

--- a/redis_instance_full/main.tf
+++ b/redis_instance_full/main.tf
@@ -12,7 +12,7 @@ resource "google_redis_instance" "cache" {
   display_name      = "Terraform Test Instance"
   reserved_ip_range = "192.168.0.0/29"
 
-  labels {
+  labels = {
     my_key    = "my_val"
     other_key = "other_val"
   }

--- a/region_autoscaler_basic/main.tf
+++ b/region_autoscaler_basic/main.tf
@@ -46,10 +46,7 @@ resource "google_compute_region_instance_group_manager" "foobar" {
   name   = "my-region-igm-${local.name_suffix}"
   region = "us-central1"
 
-  version {
-    instance_template  = "${google_compute_instance_template.foobar.self_link}"
-    name               = "primary"
-  }
+  instance_template  = "${google_compute_instance_template.foobar.self_link}"
   target_pools       = ["${google_compute_target_pool.foobar.self_link}"]
   base_instance_name = "foobar"
 }

--- a/region_autoscaler_basic/main.tf
+++ b/region_autoscaler_basic/main.tf
@@ -3,7 +3,7 @@ resource "google_compute_region_autoscaler" "foobar" {
   region = "us-central1"
   target = "${google_compute_region_instance_group_manager.foobar.self_link}"
 
-  autoscaling_policy = {
+  autoscaling_policy {
     max_replicas    = 5
     min_replicas    = 1
     cooldown_period = 60
@@ -29,7 +29,7 @@ resource "google_compute_instance_template" "foobar" {
     network = "default"
   }
 
-  metadata {
+  metadata = {
     foo = "bar"
   }
 
@@ -46,7 +46,10 @@ resource "google_compute_region_instance_group_manager" "foobar" {
   name   = "my-region-igm-${local.name_suffix}"
   region = "us-central1"
 
-  instance_template  = "${google_compute_instance_template.foobar.self_link}"
+  version {
+    instance_template  = "${google_compute_instance_template.foobar.self_link}"
+    name               = "primary"
+  }
   target_pools       = ["${google_compute_target_pool.foobar.self_link}"]
   base_instance_name = "foobar"
 }

--- a/snapshot_basic/backing_file.tf
+++ b/snapshot_basic/backing_file.tf
@@ -1,0 +1,15 @@
+# This file has some scaffolding to make sure that names are unique and that
+# a region and zone are selected when you try to create your Terraform resources.
+
+locals {
+  name_suffix = "${random_pet.suffix.id}"
+}
+
+resource "random_pet" "suffix" {
+  length = 2
+}
+
+provider "google" {
+  region = "us-central1"
+  zone   = "us-central1-c"
+}

--- a/snapshot_basic/main.tf
+++ b/snapshot_basic/main.tf
@@ -1,0 +1,21 @@
+resource "google_compute_snapshot" "snapshot" {
+	name = "my-snapshot-${local.name_suffix}"
+	source_disk = "${google_compute_disk.persistent.name}"
+	zone = "us-central1-a"
+	labels = {
+		my_label = "value"
+	}
+}
+
+data "google_compute_image" "debian" {
+	family  = "debian-9"
+	project = "debian-cloud"
+}
+
+resource "google_compute_disk" "persistent" {
+	name = "debian-disk-${local.name_suffix}"
+	image = "${data.google_compute_image.debian.self_link}"
+	size = 10
+	type = "pd-ssd"
+	zone = "us-central1-a"
+}

--- a/snapshot_basic/motd
+++ b/snapshot_basic/motd
@@ -1,0 +1,7 @@
+===
+
+These examples use real resources that will be billed to the
+Google Cloud Platform project you use - so make sure that you
+run "terraform destroy" before quitting!
+
+===

--- a/snapshot_basic/tutorial.md
+++ b/snapshot_basic/tutorial.md
@@ -1,0 +1,79 @@
+# Snapshot Basic - Terraform
+
+## Setup
+
+<walkthrough-author name="rileykarson@google.com" analyticsId="UA-125550242-1" tutorialName="snapshot_basic" repositoryUrl="https://github.com/terraform-google-modules/docs-examples"></walkthrough-author>
+
+Welcome to Terraform in Google Cloud Shell! We need you to let us know what project you'd like to use with Terraform.
+
+<walkthrough-project-billing-setup></walkthrough-project-billing-setup>
+
+Terraform provisions real GCP resources, so anything you create in this session will be billed against this project.
+
+## Terraforming!
+
+Let's use {{project-id}} with Terraform! Click the Cloud Shell icon below to copy the command
+to your shell, and then run it from the shell by pressing Enter/Return. Terraform will pick up
+the project name from the environment variable.
+
+```bash
+export GOOGLE_CLOUD_PROJECT={{project-id}}
+```
+
+After that, let's get Terraform started. Run the following to pull in the providers.
+
+```bash
+terraform init
+```
+
+With the providers downloaded and a project set, you're ready to use Terraform. Go ahead!
+
+```bash
+terraform apply
+```
+
+Terraform will show you what it plans to do, and prompt you to accept. Type "yes" to accept the plan.
+
+```bash
+yes
+```
+
+
+## Post-Apply
+
+### Editing your config
+
+Now you've provisioned your resources in GCP! If you run a "plan", you should see no changes needed.
+
+```bash
+terraform plan
+```
+
+So let's make a change! Try editing a number, or appending a value to the name in the editor. Then,
+run a 'plan' again.
+
+```bash
+terraform plan
+```
+
+Afterwards you can run an apply, which implicitly does a plan and shows you the intended changes
+at the 'yes' prompt.
+
+```bash
+terraform apply
+```
+
+```bash
+yes
+```
+
+## Cleanup
+
+Run the following to remove the resources Terraform provisioned:
+
+```bash
+terraform destroy
+```
+```bash
+yes
+```

--- a/sourcerepo_repository_basic/backing_file.tf
+++ b/sourcerepo_repository_basic/backing_file.tf
@@ -1,0 +1,15 @@
+# This file has some scaffolding to make sure that names are unique and that
+# a region and zone are selected when you try to create your Terraform resources.
+
+locals {
+  name_suffix = "${random_pet.suffix.id}"
+}
+
+resource "random_pet" "suffix" {
+  length = 2
+}
+
+provider "google" {
+  region = "us-central1"
+  zone   = "us-central1-c"
+}

--- a/sourcerepo_repository_basic/main.tf
+++ b/sourcerepo_repository_basic/main.tf
@@ -1,0 +1,3 @@
+resource "google_sourcerepo_repository" "my-repo" {
+  name = "my-repository-${local.name_suffix}"
+}

--- a/sourcerepo_repository_basic/motd
+++ b/sourcerepo_repository_basic/motd
@@ -1,0 +1,7 @@
+===
+
+These examples use real resources that will be billed to the
+Google Cloud Platform project you use - so make sure that you
+run "terraform destroy" before quitting!
+
+===

--- a/sourcerepo_repository_basic/tutorial.md
+++ b/sourcerepo_repository_basic/tutorial.md
@@ -1,0 +1,79 @@
+# Sourcerepo Repository Basic - Terraform
+
+## Setup
+
+<walkthrough-author name="rileykarson@google.com" analyticsId="UA-125550242-1" tutorialName="sourcerepo_repository_basic" repositoryUrl="https://github.com/terraform-google-modules/docs-examples"></walkthrough-author>
+
+Welcome to Terraform in Google Cloud Shell! We need you to let us know what project you'd like to use with Terraform.
+
+<walkthrough-project-billing-setup></walkthrough-project-billing-setup>
+
+Terraform provisions real GCP resources, so anything you create in this session will be billed against this project.
+
+## Terraforming!
+
+Let's use {{project-id}} with Terraform! Click the Cloud Shell icon below to copy the command
+to your shell, and then run it from the shell by pressing Enter/Return. Terraform will pick up
+the project name from the environment variable.
+
+```bash
+export GOOGLE_CLOUD_PROJECT={{project-id}}
+```
+
+After that, let's get Terraform started. Run the following to pull in the providers.
+
+```bash
+terraform init
+```
+
+With the providers downloaded and a project set, you're ready to use Terraform. Go ahead!
+
+```bash
+terraform apply
+```
+
+Terraform will show you what it plans to do, and prompt you to accept. Type "yes" to accept the plan.
+
+```bash
+yes
+```
+
+
+## Post-Apply
+
+### Editing your config
+
+Now you've provisioned your resources in GCP! If you run a "plan", you should see no changes needed.
+
+```bash
+terraform plan
+```
+
+So let's make a change! Try editing a number, or appending a value to the name in the editor. Then,
+run a 'plan' again.
+
+```bash
+terraform plan
+```
+
+Afterwards you can run an apply, which implicitly does a plan and shows you the intended changes
+at the 'yes' prompt.
+
+```bash
+terraform apply
+```
+
+```bash
+yes
+```
+
+## Cleanup
+
+Run the following to remove the resources Terraform provisioned:
+
+```bash
+terraform destroy
+```
+```bash
+yes
+```

--- a/spanner_database_basic/backing_file.tf
+++ b/spanner_database_basic/backing_file.tf
@@ -1,0 +1,15 @@
+# This file has some scaffolding to make sure that names are unique and that
+# a region and zone are selected when you try to create your Terraform resources.
+
+locals {
+  name_suffix = "${random_pet.suffix.id}"
+}
+
+resource "random_pet" "suffix" {
+  length = 2
+}
+
+provider "google" {
+  region = "us-central1"
+  zone   = "us-central1-c"
+}

--- a/spanner_database_basic/main.tf
+++ b/spanner_database_basic/main.tf
@@ -1,0 +1,13 @@
+resource "google_spanner_instance" "main" {
+  config       = "regional-europe-west1"
+  display_name = "main-instance"
+}
+
+resource "google_spanner_database" "database" {
+  instance  = "${google_spanner_instance.main.name}"
+  name      = "my-database-${local.name_suffix}"
+  ddl       =  [
+    "CREATE TABLE t1 (t1 INT64 NOT NULL,) PRIMARY KEY(t1)",
+    "CREATE TABLE t2 (t2 INT64 NOT NULL,) PRIMARY KEY(t2)"
+  ]
+}

--- a/spanner_database_basic/motd
+++ b/spanner_database_basic/motd
@@ -1,0 +1,7 @@
+===
+
+These examples use real resources that will be billed to the
+Google Cloud Platform project you use - so make sure that you
+run "terraform destroy" before quitting!
+
+===

--- a/spanner_database_basic/tutorial.md
+++ b/spanner_database_basic/tutorial.md
@@ -1,0 +1,79 @@
+# Spanner Database Basic - Terraform
+
+## Setup
+
+<walkthrough-author name="rileykarson@google.com" analyticsId="UA-125550242-1" tutorialName="spanner_database_basic" repositoryUrl="https://github.com/terraform-google-modules/docs-examples"></walkthrough-author>
+
+Welcome to Terraform in Google Cloud Shell! We need you to let us know what project you'd like to use with Terraform.
+
+<walkthrough-project-billing-setup></walkthrough-project-billing-setup>
+
+Terraform provisions real GCP resources, so anything you create in this session will be billed against this project.
+
+## Terraforming!
+
+Let's use {{project-id}} with Terraform! Click the Cloud Shell icon below to copy the command
+to your shell, and then run it from the shell by pressing Enter/Return. Terraform will pick up
+the project name from the environment variable.
+
+```bash
+export GOOGLE_CLOUD_PROJECT={{project-id}}
+```
+
+After that, let's get Terraform started. Run the following to pull in the providers.
+
+```bash
+terraform init
+```
+
+With the providers downloaded and a project set, you're ready to use Terraform. Go ahead!
+
+```bash
+terraform apply
+```
+
+Terraform will show you what it plans to do, and prompt you to accept. Type "yes" to accept the plan.
+
+```bash
+yes
+```
+
+
+## Post-Apply
+
+### Editing your config
+
+Now you've provisioned your resources in GCP! If you run a "plan", you should see no changes needed.
+
+```bash
+terraform plan
+```
+
+So let's make a change! Try editing a number, or appending a value to the name in the editor. Then,
+run a 'plan' again.
+
+```bash
+terraform plan
+```
+
+Afterwards you can run an apply, which implicitly does a plan and shows you the intended changes
+at the 'yes' prompt.
+
+```bash
+terraform apply
+```
+
+```bash
+yes
+```
+
+## Cleanup
+
+Run the following to remove the resources Terraform provisioned:
+
+```bash
+terraform destroy
+```
+```bash
+yes
+```

--- a/spanner_instance_basic/backing_file.tf
+++ b/spanner_instance_basic/backing_file.tf
@@ -1,0 +1,15 @@
+# This file has some scaffolding to make sure that names are unique and that
+# a region and zone are selected when you try to create your Terraform resources.
+
+locals {
+  name_suffix = "${random_pet.suffix.id}"
+}
+
+resource "random_pet" "suffix" {
+  length = 2
+}
+
+provider "google" {
+  region = "us-central1"
+  zone   = "us-central1-c"
+}

--- a/spanner_instance_basic/main.tf
+++ b/spanner_instance_basic/main.tf
@@ -1,0 +1,8 @@
+resource "google_spanner_instance" "example" {
+  config        = "regional-us-central1"
+  display_name  = "Test Spanner Instance"
+  num_nodes     = 2
+  labels = {
+    "foo" = "bar"
+  }
+}

--- a/spanner_instance_basic/motd
+++ b/spanner_instance_basic/motd
@@ -1,0 +1,7 @@
+===
+
+These examples use real resources that will be billed to the
+Google Cloud Platform project you use - so make sure that you
+run "terraform destroy" before quitting!
+
+===

--- a/spanner_instance_basic/tutorial.md
+++ b/spanner_instance_basic/tutorial.md
@@ -1,0 +1,79 @@
+# Spanner Instance Basic - Terraform
+
+## Setup
+
+<walkthrough-author name="rileykarson@google.com" analyticsId="UA-125550242-1" tutorialName="spanner_instance_basic" repositoryUrl="https://github.com/terraform-google-modules/docs-examples"></walkthrough-author>
+
+Welcome to Terraform in Google Cloud Shell! We need you to let us know what project you'd like to use with Terraform.
+
+<walkthrough-project-billing-setup></walkthrough-project-billing-setup>
+
+Terraform provisions real GCP resources, so anything you create in this session will be billed against this project.
+
+## Terraforming!
+
+Let's use {{project-id}} with Terraform! Click the Cloud Shell icon below to copy the command
+to your shell, and then run it from the shell by pressing Enter/Return. Terraform will pick up
+the project name from the environment variable.
+
+```bash
+export GOOGLE_CLOUD_PROJECT={{project-id}}
+```
+
+After that, let's get Terraform started. Run the following to pull in the providers.
+
+```bash
+terraform init
+```
+
+With the providers downloaded and a project set, you're ready to use Terraform. Go ahead!
+
+```bash
+terraform apply
+```
+
+Terraform will show you what it plans to do, and prompt you to accept. Type "yes" to accept the plan.
+
+```bash
+yes
+```
+
+
+## Post-Apply
+
+### Editing your config
+
+Now you've provisioned your resources in GCP! If you run a "plan", you should see no changes needed.
+
+```bash
+terraform plan
+```
+
+So let's make a change! Try editing a number, or appending a value to the name in the editor. Then,
+run a 'plan' again.
+
+```bash
+terraform plan
+```
+
+Afterwards you can run an apply, which implicitly does a plan and shows you the intended changes
+at the 'yes' prompt.
+
+```bash
+terraform apply
+```
+
+```bash
+yes
+```
+
+## Cleanup
+
+Run the following to remove the resources Terraform provisioned:
+
+```bash
+terraform destroy
+```
+```bash
+yes
+```

--- a/ssl_certificate_random_provider/main.tf
+++ b/ssl_certificate_random_provider/main.tf
@@ -16,7 +16,7 @@ resource "random_id" "certificate" {
   prefix      = "my-certificate-"
 
   # For security, do not expose raw certificate values in the output
-  keepers {
+  keepers = {
     private_key = "${base64sha256(file("../static/ssl_cert/test.key"))}"
     certificate = "${base64sha256(file("../static/ssl_cert/test.crt"))}"
   }

--- a/storage_default_object_access_control_public/backing_file.tf
+++ b/storage_default_object_access_control_public/backing_file.tf
@@ -1,0 +1,15 @@
+# This file has some scaffolding to make sure that names are unique and that
+# a region and zone are selected when you try to create your Terraform resources.
+
+locals {
+  name_suffix = "${random_pet.suffix.id}"
+}
+
+resource "random_pet" "suffix" {
+  length = 2
+}
+
+provider "google" {
+  region = "us-central1"
+  zone   = "us-central1-c"
+}

--- a/storage_default_object_access_control_public/main.tf
+++ b/storage_default_object_access_control_public/main.tf
@@ -1,0 +1,9 @@
+resource "google_storage_default_object_access_control" "public_rule" {
+  bucket = "${google_storage_bucket.bucket.name}"
+  role   = "READER"
+  entity = "allUsers"
+}
+
+resource "google_storage_bucket" "bucket" {
+	name = "static-content-bucket-${local.name_suffix}"
+}

--- a/storage_default_object_access_control_public/motd
+++ b/storage_default_object_access_control_public/motd
@@ -1,0 +1,7 @@
+===
+
+These examples use real resources that will be billed to the
+Google Cloud Platform project you use - so make sure that you
+run "terraform destroy" before quitting!
+
+===

--- a/storage_default_object_access_control_public/tutorial.md
+++ b/storage_default_object_access_control_public/tutorial.md
@@ -1,0 +1,79 @@
+# Storage Default Object Access Control Public - Terraform
+
+## Setup
+
+<walkthrough-author name="rileykarson@google.com" analyticsId="UA-125550242-1" tutorialName="storage_default_object_access_control_public" repositoryUrl="https://github.com/terraform-google-modules/docs-examples"></walkthrough-author>
+
+Welcome to Terraform in Google Cloud Shell! We need you to let us know what project you'd like to use with Terraform.
+
+<walkthrough-project-billing-setup></walkthrough-project-billing-setup>
+
+Terraform provisions real GCP resources, so anything you create in this session will be billed against this project.
+
+## Terraforming!
+
+Let's use {{project-id}} with Terraform! Click the Cloud Shell icon below to copy the command
+to your shell, and then run it from the shell by pressing Enter/Return. Terraform will pick up
+the project name from the environment variable.
+
+```bash
+export GOOGLE_CLOUD_PROJECT={{project-id}}
+```
+
+After that, let's get Terraform started. Run the following to pull in the providers.
+
+```bash
+terraform init
+```
+
+With the providers downloaded and a project set, you're ready to use Terraform. Go ahead!
+
+```bash
+terraform apply
+```
+
+Terraform will show you what it plans to do, and prompt you to accept. Type "yes" to accept the plan.
+
+```bash
+yes
+```
+
+
+## Post-Apply
+
+### Editing your config
+
+Now you've provisioned your resources in GCP! If you run a "plan", you should see no changes needed.
+
+```bash
+terraform plan
+```
+
+So let's make a change! Try editing a number, or appending a value to the name in the editor. Then,
+run a 'plan' again.
+
+```bash
+terraform plan
+```
+
+Afterwards you can run an apply, which implicitly does a plan and shows you the intended changes
+at the 'yes' prompt.
+
+```bash
+terraform apply
+```
+
+```bash
+yes
+```
+
+## Cleanup
+
+Run the following to remove the resources Terraform provisioned:
+
+```bash
+terraform destroy
+```
+```bash
+yes
+```

--- a/storage_object_access_control_public_object/backing_file.tf
+++ b/storage_object_access_control_public_object/backing_file.tf
@@ -1,0 +1,15 @@
+# This file has some scaffolding to make sure that names are unique and that
+# a region and zone are selected when you try to create your Terraform resources.
+
+locals {
+  name_suffix = "${random_pet.suffix.id}"
+}
+
+resource "random_pet" "suffix" {
+  length = 2
+}
+
+provider "google" {
+  region = "us-central1"
+  zone   = "us-central1-c"
+}

--- a/storage_object_access_control_public_object/main.tf
+++ b/storage_object_access_control_public_object/main.tf
@@ -1,0 +1,16 @@
+resource "google_storage_object_access_control" "public_rule" {
+  object = "${google_storage_bucket_object.object.name}"
+  bucket = "${google_storage_bucket.bucket.name}"
+  role   = "READER"
+  entity = "allUsers"
+}
+
+resource "google_storage_bucket" "bucket" {
+	name = "static-content-bucket-${local.name_suffix}"
+}
+
+ resource "google_storage_bucket_object" "object" {
+	name   = "public-object-${local.name_suffix}"
+	bucket = "${google_storage_bucket.bucket.name}"
+	source = "../static/header-logo.png"
+}

--- a/storage_object_access_control_public_object/motd
+++ b/storage_object_access_control_public_object/motd
@@ -1,0 +1,7 @@
+===
+
+These examples use real resources that will be billed to the
+Google Cloud Platform project you use - so make sure that you
+run "terraform destroy" before quitting!
+
+===

--- a/storage_object_access_control_public_object/tutorial.md
+++ b/storage_object_access_control_public_object/tutorial.md
@@ -1,0 +1,79 @@
+# Storage Object Access Control Public Object - Terraform
+
+## Setup
+
+<walkthrough-author name="rileykarson@google.com" analyticsId="UA-125550242-1" tutorialName="storage_object_access_control_public_object" repositoryUrl="https://github.com/terraform-google-modules/docs-examples"></walkthrough-author>
+
+Welcome to Terraform in Google Cloud Shell! We need you to let us know what project you'd like to use with Terraform.
+
+<walkthrough-project-billing-setup></walkthrough-project-billing-setup>
+
+Terraform provisions real GCP resources, so anything you create in this session will be billed against this project.
+
+## Terraforming!
+
+Let's use {{project-id}} with Terraform! Click the Cloud Shell icon below to copy the command
+to your shell, and then run it from the shell by pressing Enter/Return. Terraform will pick up
+the project name from the environment variable.
+
+```bash
+export GOOGLE_CLOUD_PROJECT={{project-id}}
+```
+
+After that, let's get Terraform started. Run the following to pull in the providers.
+
+```bash
+terraform init
+```
+
+With the providers downloaded and a project set, you're ready to use Terraform. Go ahead!
+
+```bash
+terraform apply
+```
+
+Terraform will show you what it plans to do, and prompt you to accept. Type "yes" to accept the plan.
+
+```bash
+yes
+```
+
+
+## Post-Apply
+
+### Editing your config
+
+Now you've provisioned your resources in GCP! If you run a "plan", you should see no changes needed.
+
+```bash
+terraform plan
+```
+
+So let's make a change! Try editing a number, or appending a value to the name in the editor. Then,
+run a 'plan' again.
+
+```bash
+terraform plan
+```
+
+Afterwards you can run an apply, which implicitly does a plan and shows you the intended changes
+at the 'yes' prompt.
+
+```bash
+terraform apply
+```
+
+```bash
+yes
+```
+
+## Cleanup
+
+Run the following to remove the resources Terraform provisioned:
+
+```bash
+terraform destroy
+```
+```bash
+yes
+```

--- a/uptime_check_config_http/backing_file.tf
+++ b/uptime_check_config_http/backing_file.tf
@@ -1,0 +1,15 @@
+# This file has some scaffolding to make sure that names are unique and that
+# a region and zone are selected when you try to create your Terraform resources.
+
+locals {
+  name_suffix = "${random_pet.suffix.id}"
+}
+
+resource "random_pet" "suffix" {
+  length = 2
+}
+
+provider "google" {
+  region = "us-central1"
+  zone   = "us-central1-c"
+}

--- a/uptime_check_config_http/main.tf
+++ b/uptime_check_config_http/main.tf
@@ -1,0 +1,21 @@
+resource "google_monitoring_uptime_check_config" "http" {
+  display_name = "http-uptime-check-${local.name_suffix}"
+  timeout = "60s"
+
+  http_check {
+    path = "/some-path"
+    port = "8010"
+  }
+
+  monitored_resource {
+    type = "uptime_url"
+    labels = {
+      project_id = "example"
+      host = "192.168.1.1"
+    }
+  }
+
+  content_matchers {
+    content = "example"
+  }
+}

--- a/uptime_check_config_http/motd
+++ b/uptime_check_config_http/motd
@@ -1,0 +1,7 @@
+===
+
+These examples use real resources that will be billed to the
+Google Cloud Platform project you use - so make sure that you
+run "terraform destroy" before quitting!
+
+===

--- a/uptime_check_config_http/tutorial.md
+++ b/uptime_check_config_http/tutorial.md
@@ -1,0 +1,79 @@
+# Uptime Check Config Http - Terraform
+
+## Setup
+
+<walkthrough-author name="rileykarson@google.com" analyticsId="UA-125550242-1" tutorialName="uptime_check_config_http" repositoryUrl="https://github.com/terraform-google-modules/docs-examples"></walkthrough-author>
+
+Welcome to Terraform in Google Cloud Shell! We need you to let us know what project you'd like to use with Terraform.
+
+<walkthrough-project-billing-setup></walkthrough-project-billing-setup>
+
+Terraform provisions real GCP resources, so anything you create in this session will be billed against this project.
+
+## Terraforming!
+
+Let's use {{project-id}} with Terraform! Click the Cloud Shell icon below to copy the command
+to your shell, and then run it from the shell by pressing Enter/Return. Terraform will pick up
+the project name from the environment variable.
+
+```bash
+export GOOGLE_CLOUD_PROJECT={{project-id}}
+```
+
+After that, let's get Terraform started. Run the following to pull in the providers.
+
+```bash
+terraform init
+```
+
+With the providers downloaded and a project set, you're ready to use Terraform. Go ahead!
+
+```bash
+terraform apply
+```
+
+Terraform will show you what it plans to do, and prompt you to accept. Type "yes" to accept the plan.
+
+```bash
+yes
+```
+
+
+## Post-Apply
+
+### Editing your config
+
+Now you've provisioned your resources in GCP! If you run a "plan", you should see no changes needed.
+
+```bash
+terraform plan
+```
+
+So let's make a change! Try editing a number, or appending a value to the name in the editor. Then,
+run a 'plan' again.
+
+```bash
+terraform plan
+```
+
+Afterwards you can run an apply, which implicitly does a plan and shows you the intended changes
+at the 'yes' prompt.
+
+```bash
+terraform apply
+```
+
+```bash
+yes
+```
+
+## Cleanup
+
+Run the following to remove the resources Terraform provisioned:
+
+```bash
+terraform destroy
+```
+```bash
+yes
+```

--- a/uptime_check_tcp/backing_file.tf
+++ b/uptime_check_tcp/backing_file.tf
@@ -1,0 +1,15 @@
+# This file has some scaffolding to make sure that names are unique and that
+# a region and zone are selected when you try to create your Terraform resources.
+
+locals {
+  name_suffix = "${random_pet.suffix.id}"
+}
+
+resource "random_pet" "suffix" {
+  length = 2
+}
+
+provider "google" {
+  region = "us-central1"
+  zone   = "us-central1-c"
+}

--- a/uptime_check_tcp/main.tf
+++ b/uptime_check_tcp/main.tf
@@ -1,0 +1,19 @@
+resource "google_monitoring_uptime_check_config" "tcp_group" {
+  display_name = "tcp-uptime-check-${local.name_suffix}"
+  timeout = "60s"
+
+  tcp_check {
+    port = 888
+  }
+
+  resource_group {
+    resource_type = "INSTANCE"
+    group_id = "${google_monitoring_group.check.name}"
+  }
+}
+
+
+resource "google_monitoring_group" "check" {
+  display_name = "uptime-check-group-${local.name_suffix}"
+  filter = "resource.metadata.name=has_substring(\"foo\")"
+}

--- a/uptime_check_tcp/motd
+++ b/uptime_check_tcp/motd
@@ -1,0 +1,7 @@
+===
+
+These examples use real resources that will be billed to the
+Google Cloud Platform project you use - so make sure that you
+run "terraform destroy" before quitting!
+
+===

--- a/uptime_check_tcp/tutorial.md
+++ b/uptime_check_tcp/tutorial.md
@@ -1,0 +1,79 @@
+# Uptime Check Tcp - Terraform
+
+## Setup
+
+<walkthrough-author name="rileykarson@google.com" analyticsId="UA-125550242-1" tutorialName="uptime_check_tcp" repositoryUrl="https://github.com/terraform-google-modules/docs-examples"></walkthrough-author>
+
+Welcome to Terraform in Google Cloud Shell! We need you to let us know what project you'd like to use with Terraform.
+
+<walkthrough-project-billing-setup></walkthrough-project-billing-setup>
+
+Terraform provisions real GCP resources, so anything you create in this session will be billed against this project.
+
+## Terraforming!
+
+Let's use {{project-id}} with Terraform! Click the Cloud Shell icon below to copy the command
+to your shell, and then run it from the shell by pressing Enter/Return. Terraform will pick up
+the project name from the environment variable.
+
+```bash
+export GOOGLE_CLOUD_PROJECT={{project-id}}
+```
+
+After that, let's get Terraform started. Run the following to pull in the providers.
+
+```bash
+terraform init
+```
+
+With the providers downloaded and a project set, you're ready to use Terraform. Go ahead!
+
+```bash
+terraform apply
+```
+
+Terraform will show you what it plans to do, and prompt you to accept. Type "yes" to accept the plan.
+
+```bash
+yes
+```
+
+
+## Post-Apply
+
+### Editing your config
+
+Now you've provisioned your resources in GCP! If you run a "plan", you should see no changes needed.
+
+```bash
+terraform plan
+```
+
+So let's make a change! Try editing a number, or appending a value to the name in the editor. Then,
+run a 'plan' again.
+
+```bash
+terraform plan
+```
+
+Afterwards you can run an apply, which implicitly does a plan and shows you the intended changes
+at the 'yes' prompt.
+
+```bash
+terraform apply
+```
+
+```bash
+yes
+```
+
+## Cleanup
+
+Run the following to remove the resources Terraform provisioned:
+
+```bash
+terraform destroy
+```
+```bash
+yes
+```


### PR DESCRIPTION
Add the examples we'll need for `2.0.0` without updating them to use the `google-beta` provider when necessary; this means `2.0.0` versions of the providers won't work until that's done, but `1.20.0` will.