### PR TITLE
Update main.tf `service` to GA

### DIFF
--- a/cloudrunv2_service_directvpc/main.tf
+++ b/cloudrunv2_service_directvpc/main.tf
@@ -1,7 +1,7 @@
 resource "google_cloud_run_v2_service" "default" {
   name     = "cloudrun-service-${local.name_suffix}"
   location = "us-central1"
-  launch_stage = "BETA"
+  launch_stage = "GA"
   template {
     containers {
       image = "us-docker.pkg.dev/cloudrun/container/hello"


### PR DESCRIPTION
Direct VPC egress for Cloud Run services is now GA: https://cloud.google.com/run/docs/release-notes#April_24_2024

We should update the sample file's launch stage accordingly.